### PR TITLE
Add declaration grouping & ordering to the renaming phase

### DIFF
--- a/compiler/common/src/main/java/org/mina_lang/common/Position.java
+++ b/compiler/common/src/main/java/org/mina_lang/common/Position.java
@@ -1,6 +1,16 @@
 package org.mina_lang.common;
 
-public record Position(int line, int character) {
+public record Position(int line, int character) implements Comparable<Position> {
     public static Position NONE = new Position(-1, -1);
 
+    @Override
+    public int compareTo(Position that) {
+        var lineComparison = Integer.compare(this.line(), that.line());
+
+        if (lineComparison != 0) {
+            return lineComparison;
+        } else {
+            return Integer.compare(this.character(), that.character());
+        }
+    }
 }

--- a/compiler/common/src/main/java/org/mina_lang/common/types/Kind.java
+++ b/compiler/common/src/main/java/org/mina_lang/common/types/Kind.java
@@ -9,12 +9,4 @@ public sealed interface Kind extends Sort permits TypeKind, HigherKind, Unsolved
     <A> A accept(KindFolder<A> visitor);
 
     Kind accept(KindTransformer visitor);
-
-    default Kind substitute(UnionFind<Kind> substitution) {
-        return accept(new KindSubstitutionTransformer(substitution));
-    }
-
-    default Kind defaultKind() {
-        return accept(new KindDefaultingTransformer());
-    }
 }

--- a/compiler/common/src/main/java/org/mina_lang/common/types/MonoType.java
+++ b/compiler/common/src/main/java/org/mina_lang/common/types/MonoType.java
@@ -4,15 +4,4 @@ public sealed interface MonoType extends Type permits TypeConstructor, BuiltInTy
 
     @Override
     MonoType accept(TypeTransformer visitor);
-
-    @Override
-    default public MonoType substitute(
-            UnionFind<MonoType> typeSubstitution,
-            UnionFind<Kind> kindSubstitution) {
-        return accept(new TypeSubstitutionTransformer(typeSubstitution, kindSubstitution));
-    }
-
-    default public MonoType defaultKinds() {
-        return accept(new TypeSubstitutionTransformer(new KindDefaultingTransformer()));
-    }
 }

--- a/compiler/common/src/main/java/org/mina_lang/common/types/PolyType.java
+++ b/compiler/common/src/main/java/org/mina_lang/common/types/PolyType.java
@@ -3,15 +3,4 @@ package org.mina_lang.common.types;
 public sealed interface PolyType extends Type permits TypeLambda, PropositionType, ImplicationType {
     @Override
     PolyType accept(TypeTransformer visitor);
-
-    @Override
-    default public PolyType substitute(
-            UnionFind<MonoType> typeSubstitution,
-            UnionFind<Kind> kindSubstitution) {
-        return accept(new TypeSubstitutionTransformer(typeSubstitution, kindSubstitution));
-    }
-
-    default public PolyType defaultKinds() {
-        return accept(new TypeSubstitutionTransformer(new KindDefaultingTransformer()));
-    }
 }

--- a/compiler/common/src/main/java/org/mina_lang/common/types/Sort.java
+++ b/compiler/common/src/main/java/org/mina_lang/common/types/Sort.java
@@ -2,10 +2,4 @@ package org.mina_lang.common.types;
 
 public sealed interface Sort permits Type, Kind {
     <A> A accept(SortFolder<A> visitor);
-
-    default Sort substitute(
-            UnionFind<MonoType> typeSubstitution,
-            UnionFind<Kind> kindSubstitution) {
-        return accept(new SortSubstitutionTransformer(typeSubstitution, kindSubstitution));
-    }
 }

--- a/compiler/common/src/main/java/org/mina_lang/common/types/SortSubstitutionTransformer.java
+++ b/compiler/common/src/main/java/org/mina_lang/common/types/SortSubstitutionTransformer.java
@@ -2,76 +2,85 @@ package org.mina_lang.common.types;
 
 public class SortSubstitutionTransformer implements SortFolder<Sort> {
 
-    public TypeSubstitutionTransformer typeSubst;
-    public KindSubstitutionTransformer kindSubst;
+    private TypeSubstitutionTransformer typeTransformer;
+
+    private KindSubstitutionTransformer kindTransformer;
 
     public SortSubstitutionTransformer(UnionFind<MonoType> typeSubstitution, KindSubstitutionTransformer kindTransformer) {
-        this.kindSubst = kindTransformer;
-        this.typeSubst = new TypeSubstitutionTransformer(typeSubstitution, kindSubst);
+        this.kindTransformer = kindTransformer;
+        this.typeTransformer = new TypeSubstitutionTransformer(typeSubstitution, kindTransformer);
     }
 
     public SortSubstitutionTransformer(UnionFind<MonoType> typeSubstitution, UnionFind<Kind> kindSubstitution) {
-        this.kindSubst = new KindSubstitutionTransformer(kindSubstitution);
-        this.typeSubst = new TypeSubstitutionTransformer(typeSubstitution, kindSubst);
+        this.kindTransformer = new KindSubstitutionTransformer(kindSubstitution);
+        this.typeTransformer = new TypeSubstitutionTransformer(typeSubstitution, kindTransformer);
+    }
+
+    public TypeSubstitutionTransformer getTypeTransformer() {
+        return typeTransformer;
+    }
+
+    public KindSubstitutionTransformer getKindTransformer() {
+        return kindTransformer;
     }
 
     @Override
     public Sort visitTypeKind(TypeKind typ) {
-        return typ.accept(kindSubst);
+        return typ.accept(kindTransformer);
     }
 
     @Override
     public Sort visitUnsolvedKind(UnsolvedKind unsolved) {
-        return unsolved.accept(kindSubst);
+        return unsolved.accept(kindTransformer);
     }
 
     @Override
     public Sort visitHigherKind(HigherKind higher) {
-        return higher.accept(kindSubst);
+        return higher.accept(kindTransformer);
     }
 
     @Override
     public Sort visitTypeLambda(TypeLambda tyLam) {
-        return tyLam.accept(typeSubst);
+        return tyLam.accept(typeTransformer);
     }
 
     @Override
     public Sort visitPropositionType(PropositionType propType) {
-        return propType.accept(typeSubst);
+        return propType.accept(typeTransformer);
     }
 
     @Override
     public Sort visitImplicationType(ImplicationType implType) {
-        return implType.accept(typeSubst);
+        return implType.accept(typeTransformer);
     }
 
     @Override
     public Sort visitTypeConstructor(TypeConstructor tyCon) {
-        return tyCon.accept(typeSubst);
+        return tyCon.accept(typeTransformer);
     }
 
     @Override
     public Sort visitBuiltInType(BuiltInType primTy) {
-        return primTy.accept(typeSubst);
+        return primTy.accept(typeTransformer);
     }
 
     @Override
     public Sort visitTypeApply(TypeApply tyApp) {
-        return tyApp.accept(typeSubst);
+        return tyApp.accept(typeTransformer);
     }
 
     @Override
     public Sort visitForAllVar(ForAllVar forall) {
-        return forall.accept(typeSubst);
+        return forall.accept(typeTransformer);
     }
 
     @Override
     public Sort visitExistsVar(ExistsVar exists) {
-        return exists.accept(typeSubst);
+        return exists.accept(typeTransformer);
     }
 
     @Override
     public Sort visitUnsolvedType(UnsolvedType unsolved) {
-        return unsolved.accept(typeSubst);
+        return unsolved.accept(typeTransformer);
     }
 }

--- a/compiler/common/src/main/java/org/mina_lang/common/types/Type.java
+++ b/compiler/common/src/main/java/org/mina_lang/common/types/Type.java
@@ -27,16 +27,6 @@ sealed public interface Type extends Sort permits PolyType, MonoType {
 
     public Type accept(TypeTransformer visitor);
 
-    default public Type substitute(
-            UnionFind<MonoType> typeSubstitution,
-            UnionFind<Kind> kindSubstitution) {
-        return accept(new TypeSubstitutionTransformer(typeSubstitution, kindSubstitution));
-    }
-
-    default public Type defaultKinds() {
-        return accept(new TypeSubstitutionTransformer(new KindDefaultingTransformer()));
-    }
-
     public static boolean isFunction(Type type) {
         if (type instanceof TypeApply tyApp) {
             if (tyApp.type() instanceof BuiltInType builtIn) {

--- a/compiler/jvm/src/main/java/org/mina_lang/codegen/jvm/CodeGenerator.java
+++ b/compiler/jvm/src/main/java/org/mina_lang/codegen/jvm/CodeGenerator.java
@@ -132,25 +132,28 @@ public class CodeGenerator {
     }
 
     public void populateTopLevel(NamespaceNode<Attributes> namespace) {
-        namespace.declarations().forEach(decl -> {
-            if (decl instanceof LetNode<Attributes> let) {
-                putValueDeclaration(let.meta());
-            } else if (decl instanceof LetFnNode<Attributes> letFn) {
-                putValueDeclaration(letFn.meta());
-            } else if (decl instanceof DataNode<Attributes> data) {
-                putTypeDeclaration(data.meta());
+        namespace.declarationGroups().forEach(decls -> {
+            decls.forEach(decl -> {
+                if (decl instanceof LetNode<Attributes> let) {
+                    putValueDeclaration(let.meta());
+                } else if (decl instanceof LetFnNode<Attributes> letFn) {
+                    putValueDeclaration(letFn.meta());
+                } else if (decl instanceof DataNode<Attributes> data) {
+                    putTypeDeclaration(data.meta());
 
-                data.constructors().forEach(constr -> {
-                    putValueDeclaration(constr.meta());
+                    data.constructors().forEach(constr -> {
+                        putValueDeclaration(constr.meta());
 
-                    constr.params().forEach(constrParam -> {
-                        environment.putField(
-                                (ConstructorName) constr.meta().meta().name(),
-                                constrParam.name(),
-                                constrParam.meta());
+                        constr.params().forEach(constrParam -> {
+                            environment.putField(
+                                    (ConstructorName) constr.meta().meta().name(),
+                                    constrParam.name(),
+                                    constrParam.meta());
+                        });
                     });
-                });
-            }
+                }
+
+            });
         });
     }
 
@@ -158,8 +161,8 @@ public class CodeGenerator {
         withScope(NamespaceGenScope.open(namespace), namespaceScope -> {
             populateTopLevel(namespace);
 
-            namespace.declarations()
-                    .forEach(this::generateDeclaration);
+            namespace.declarationGroups()
+                    .forEach(decls -> decls.forEach(this::generateDeclaration));
 
             classes.put(
                     Names.getName(namespace),

--- a/compiler/jvm/src/main/java/org/mina_lang/codegen/jvm/FreeVariablesFolder.java
+++ b/compiler/jvm/src/main/java/org/mina_lang/codegen/jvm/FreeVariablesFolder.java
@@ -74,7 +74,7 @@ public class FreeVariablesFolder implements MetaNodeFolder<Attributes, Immutable
 
     @Override
     public ImmutableList<ReferenceNode<Attributes>> visitNamespace(Meta<Attributes> meta, NamespaceIdNode id,
-            ImmutableList<ImportNode> imports, ImmutableList<ImmutableList<ReferenceNode<Attributes>>> declarations) {
+            ImmutableList<ImportNode> imports, ImmutableList<ImmutableList<ImmutableList<ReferenceNode<Attributes>>>> declarationGroups) {
         return Lists.immutable.empty();
     }
 

--- a/compiler/parser/src/main/java/org/mina_lang/parser/Parser.java
+++ b/compiler/parser/src/main/java/org/mina_lang/parser/Parser.java
@@ -652,12 +652,8 @@ public class Parser {
 
         @Override
         public NamespaceIdNode visitNamespaceId(NamespaceIdContext ctx) {
-            var pkg = ctx.pkg.stream()
-                    .map(Token::getText)
-                    .collect(Collectors2.toImmutableList());
-
+            var pkg = Lists.immutable.ofAll(ctx.pkg).collect(Token::getText);
             var ns = Optional.ofNullable(ctx.ns).map(Token::getText).orElse(null);
-
             return nsIdNode(contextRange(ctx), pkg, ns);
         }
     }

--- a/compiler/renamer/build.gradle.kts
+++ b/compiler/renamer/build.gradle.kts
@@ -12,4 +12,7 @@ dependencies {
 
     // Syntax Tree Definitions
     implementation(project(":compiler:syntax"))
+
+    // Graph data structures
+    implementation(libs.jgrapht)
 }

--- a/compiler/renamer/src/main/java/org/mina_lang/renamer/NameEnvironment.java
+++ b/compiler/renamer/src/main/java/org/mina_lang/renamer/NameEnvironment.java
@@ -16,6 +16,12 @@ public record NameEnvironment(MutableStack<NamingScope> scopes) implements Envir
                 .map(scope -> (NamespaceNamingScope) scope);
     }
 
+    public Optional<DeclarationNamingScope> enclosingDeclaration() {
+        return scopes()
+                .detectOptional(scope -> scope instanceof DeclarationNamingScope)
+                .map(scope -> (DeclarationNamingScope) scope);
+    }
+
     public Optional<DataNamingScope> enclosingData() {
         return scopes()
                 .detectOptional(scope -> scope instanceof DataNamingScope)
@@ -26,6 +32,12 @@ public record NameEnvironment(MutableStack<NamingScope> scopes) implements Envir
         return scopes()
                 .detectOptional(scope -> scope instanceof ConstructorNamingScope)
                 .map(scope -> (ConstructorNamingScope) scope);
+    }
+
+    public Optional<LetNamingScope> enclosingLet() {
+        return scopes()
+                .detectOptional(scope -> scope instanceof LetNamingScope)
+                .map(scope -> (LetNamingScope) scope);
     }
 
     public Optional<LambdaNamingScope> enclosingLambda() {

--- a/compiler/renamer/src/main/java/org/mina_lang/renamer/Renamer.java
+++ b/compiler/renamer/src/main/java/org/mina_lang/renamer/Renamer.java
@@ -174,7 +174,7 @@ public class Renamer {
             var namespaceMeta = new Meta<Name>(meta.range(), environment.enclosingNamespace().get().namespace());
 
             var connectedComponents = new KosarajuStrongConnectivityInspector<>(declarationGraph)
-                .stronglyConnectedSets();
+                    .stronglyConnectedSets();
 
             if (connectedComponents.isEmpty()) {
                 return new NamespaceNode<>(namespaceMeta, id, imports, declarationGroups);
@@ -197,6 +197,15 @@ public class Renamer {
                         sortedDeclarations.add(declarationGroup);
                     }
                 });
+
+                var disconnectedComponents = unsortedDeclarations
+                        .reject(unsortedDecl -> sortedDeclarations
+                                .anySatisfy(declGroup -> declGroup.contains(unsortedDecl)))
+                        .toImmutableList();
+
+                if (!disconnectedComponents.isEmpty()) {
+                    sortedDeclarations.add(disconnectedComponents);
+                }
 
                 return new NamespaceNode<>(namespaceMeta, id, imports, sortedDeclarations.toImmutable());
             }

--- a/compiler/renamer/src/main/java/org/mina_lang/renamer/scopes/DataNamingScope.java
+++ b/compiler/renamer/src/main/java/org/mina_lang/renamer/scopes/DataNamingScope.java
@@ -11,12 +11,17 @@ public record DataNamingScope(
         DataName data,
         MutableMap<String, Meta<Name>> values,
         MutableMap<String, Meta<Name>> types,
-        MutableMap<ConstructorName, MutableMap<String, Meta<Name>>> fields) implements NamingScope {
+        MutableMap<ConstructorName, MutableMap<String, Meta<Name>>> fields) implements DeclarationNamingScope {
     public DataNamingScope(DataName data) {
         this(
                 data,
                 Maps.mutable.empty(),
                 Maps.mutable.empty(),
                 Maps.mutable.empty());
+    }
+
+    @Override
+    public DataName declarationName() {
+        return data;
     }
 }

--- a/compiler/renamer/src/main/java/org/mina_lang/renamer/scopes/DeclarationNamingScope.java
+++ b/compiler/renamer/src/main/java/org/mina_lang/renamer/scopes/DeclarationNamingScope.java
@@ -1,0 +1,7 @@
+package org.mina_lang.renamer.scopes;
+
+import org.mina_lang.common.names.DeclarationName;
+
+public interface DeclarationNamingScope extends NamingScope {
+    DeclarationName declarationName();
+}

--- a/compiler/renamer/src/main/java/org/mina_lang/renamer/scopes/LetNamingScope.java
+++ b/compiler/renamer/src/main/java/org/mina_lang/renamer/scopes/LetNamingScope.java
@@ -4,24 +4,26 @@ import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.map.MutableMap;
 import org.mina_lang.common.Meta;
 import org.mina_lang.common.names.ConstructorName;
+import org.mina_lang.common.names.DeclarationName;
+import org.mina_lang.common.names.LetName;
 import org.mina_lang.common.names.Name;
 
-public record ConstructorNamingScope(
-        ConstructorName constr,
+public record LetNamingScope(
+        LetName let,
         MutableMap<String, Meta<Name>> values,
         MutableMap<String, Meta<Name>> types,
         MutableMap<ConstructorName, MutableMap<String, Meta<Name>>> fields) implements DeclarationNamingScope {
 
-    public ConstructorNamingScope(ConstructorName constr) {
+    public LetNamingScope(LetName let) {
         this(
-                constr,
+                let,
                 Maps.mutable.empty(),
                 Maps.mutable.empty(),
                 Maps.mutable.empty());
     }
 
     @Override
-    public ConstructorName declarationName() {
-        return constr;
+    public DeclarationName declarationName() {
+        return let;
     }
 }

--- a/compiler/renamer/src/test/java/org/mina_lang/renamer/RenamerTest.java
+++ b/compiler/renamer/src/test/java/org/mina_lang/renamer/RenamerTest.java
@@ -611,10 +611,10 @@ public class RenamerTest {
                         letNode(Range.EMPTY, "bar", intNode(Range.EMPTY, 1)),
                         letNode(Range.EMPTY, "foo", refNode(Range.EMPTY, "bar"))));
 
-        var expectedNode = namespaceNode(Meta.of(namespaceName), idNode, Lists.immutable.empty(),
+        var expectedNode = new NamespaceNode<>(Meta.of(namespaceName), idNode, Lists.immutable.empty(),
                 Lists.immutable.of(
-                        letNode(Meta.of(barName), "bar", intNode(Meta.of(Nameless.INSTANCE), 1)),
-                        letNode(Meta.of(fooName), "foo", refNode(Meta.of(barName), "bar"))));
+                        Lists.immutable.of(letNode(Meta.of(barName), "bar", intNode(Meta.of(Nameless.INSTANCE), 1))),
+                        Lists.immutable.of(letNode(Meta.of(fooName), "foo", refNode(Meta.of(barName), "bar")))));
 
         testSuccessfulRename(NameEnvironment.empty(), originalNode, expectedNode);
     }
@@ -1199,16 +1199,16 @@ public class RenamerTest {
                                         letNode(Range.EMPTY, "baz", refNode(Range.EMPTY, "bar"))),
                                 refNode(Range.EMPTY, "baz")))));
 
-        var expectedNode = namespaceNode(
+        var expectedNode = new NamespaceNode<>(
                 Meta.of(namespaceName), idNode,
                 Lists.immutable.empty(),
                 Lists.immutable.of(
-                        letNode(Meta.of(outerBarName), "bar", intNode(Meta.of(Nameless.INSTANCE), 1)),
-                        letNode(Meta.of(outerFooName), "foo", blockNode(
+                        Lists.immutable.of(letNode(Meta.of(outerBarName), "bar", intNode(Meta.of(Nameless.INSTANCE), 1))),
+                        Lists.immutable.of(letNode(Meta.of(outerFooName), "foo", blockNode(
                                 Meta.of(Nameless.INSTANCE),
                                 Lists.immutable.of(
                                         letNode(Meta.of(localBazName), "baz", refNode(Meta.of(outerBarName), "bar"))),
-                                refNode(Meta.of(localBazName), "baz")))));
+                                refNode(Meta.of(localBazName), "baz"))))));
 
         testSuccessfulRename(NameEnvironment.empty(), originalNode, expectedNode);
     }

--- a/compiler/syntax/src/main/java/org/mina_lang/syntax/DeclarationNode.java
+++ b/compiler/syntax/src/main/java/org/mina_lang/syntax/DeclarationNode.java
@@ -2,6 +2,8 @@ package org.mina_lang.syntax;
 
 sealed public interface DeclarationNode<A> extends MetaNode<A>permits DataNode, LetNode, LetFnNode {
 
+    String name();
+
     @Override
     <B> DeclarationNode<B> accept(MetaNodeTransformer<A, B> transformer);
 }

--- a/compiler/syntax/src/main/java/org/mina_lang/syntax/ExprNode.java
+++ b/compiler/syntax/src/main/java/org/mina_lang/syntax/ExprNode.java
@@ -1,7 +1,5 @@
 package org.mina_lang.syntax;
 
-import org.eclipse.collections.api.list.ImmutableList;
-
 sealed public interface ExprNode<A>
         extends MetaNode<A>permits BlockNode, IfNode, LambdaNode, MatchNode, ReferenceNode, LiteralNode, ApplyNode {
 

--- a/compiler/syntax/src/main/java/org/mina_lang/syntax/MetaNodeFolder.java
+++ b/compiler/syntax/src/main/java/org/mina_lang/syntax/MetaNodeFolder.java
@@ -11,7 +11,7 @@ public interface MetaNodeFolder<A, B> extends DataNodeFolder<A, B>, PatternNodeF
     default void preVisitNamespace(NamespaceNode<A> namespace) {}
 
     B visitNamespace(Meta<A> meta, NamespaceIdNode id, ImmutableList<ImportNode> imports,
-            ImmutableList<B> declarations);
+            ImmutableList<ImmutableList<B>> declarationGroups);
 
     default void postVisitNamespace(NamespaceNode<A> namespace) {}
 

--- a/compiler/syntax/src/main/java/org/mina_lang/syntax/MetaNodeMetaTransformer.java
+++ b/compiler/syntax/src/main/java/org/mina_lang/syntax/MetaNodeMetaTransformer.java
@@ -12,8 +12,8 @@ public interface MetaNodeMetaTransformer<A, B> extends MetaNodeTransformer<A, B>
     // Namespaces
     @Override
     default NamespaceNode<B> visitNamespace(Meta<A> meta, NamespaceIdNode id, ImmutableList<ImportNode> imports,
-            ImmutableList<DeclarationNode<B>> declarations) {
-        return namespaceNode(updateMeta(meta), id, imports, declarations);
+            ImmutableList<ImmutableList<DeclarationNode<B>>> declarationGroups) {
+        return new NamespaceNode<>(updateMeta(meta), id, imports, declarationGroups);
     }
 
 

--- a/compiler/syntax/src/main/java/org/mina_lang/syntax/MetaNodeTransformer.java
+++ b/compiler/syntax/src/main/java/org/mina_lang/syntax/MetaNodeTransformer.java
@@ -11,7 +11,7 @@ public interface MetaNodeTransformer<A, B> extends DataNodeTransformer<A, B>, Pa
     default void preVisitNamespace(NamespaceNode<A> namespace) {}
 
     NamespaceNode<B> visitNamespace(Meta<A> meta, NamespaceIdNode id, ImmutableList<ImportNode> imports,
-            ImmutableList<DeclarationNode<B>> declarations);
+            ImmutableList<ImmutableList<DeclarationNode<B>>> declarationGroups);
 
     default void postVisitNamespace(NamespaceNode<B> namespace) {}
 

--- a/compiler/syntax/src/main/java/org/mina_lang/syntax/NamespaceNode.java
+++ b/compiler/syntax/src/main/java/org/mina_lang/syntax/NamespaceNode.java
@@ -5,13 +5,13 @@ import org.mina_lang.common.*;
 import org.mina_lang.common.names.NamespaceName;
 
 public record NamespaceNode<A> (Meta<A> meta, NamespaceIdNode id, ImmutableList<ImportNode> imports,
-        ImmutableList<DeclarationNode<A>> declarations) implements MetaNode<A> {
+        ImmutableList<ImmutableList<DeclarationNode<A>>> declarationGroups) implements MetaNode<A> {
 
     @Override
     public void accept(SyntaxNodeVisitor visitor) {
         id.accept(visitor);
         imports.forEach(imp -> imp.accept(visitor));
-        declarations.forEach(decl -> decl.accept(visitor));
+        declarationGroups.forEach(group -> group.forEach(visitor::visitDeclaration));
         visitor.visitNamespace(this);
     }
 
@@ -23,7 +23,7 @@ public record NamespaceNode<A> (Meta<A> meta, NamespaceIdNode id, ImmutableList<
                 meta(),
                 id(),
                 imports(),
-                declarations().collect(visitor::visitDeclaration));
+                declarationGroups().collect(group -> group.collect(visitor::visitDeclaration)));
 
         visitor.postVisitNamespace(this);
 
@@ -38,7 +38,7 @@ public record NamespaceNode<A> (Meta<A> meta, NamespaceIdNode id, ImmutableList<
                 meta(),
                 id(),
                 imports(),
-                declarations().collect(visitor::visitDeclaration));
+                declarationGroups().collect(group -> group.collect(visitor::visitDeclaration)));
 
         visitor.postVisitNamespace(result);
 

--- a/compiler/syntax/src/main/java/org/mina_lang/syntax/SyntaxNodes.java
+++ b/compiler/syntax/src/main/java/org/mina_lang/syntax/SyntaxNodes.java
@@ -14,7 +14,7 @@ public class SyntaxNodes {
             NamespaceIdNode id,
             ImmutableList<ImportNode> imports,
             ImmutableList<DeclarationNode<Void>> declarations) {
-        return new NamespaceNode<>(Meta.of(range), id, imports, declarations);
+        return new NamespaceNode<>(Meta.of(range), id, imports, Lists.immutable.of(declarations));
     }
 
     public static <A> NamespaceNode<A> namespaceNode(
@@ -22,7 +22,7 @@ public class SyntaxNodes {
             NamespaceIdNode id,
             ImmutableList<ImportNode> imports,
             ImmutableList<DeclarationNode<A>> declarations) {
-        return new NamespaceNode<>(meta, id, imports, declarations);
+        return new NamespaceNode<>(meta, id, imports, Lists.immutable.of(declarations));
     }
 
     public static ImportNode importNode(

--- a/compiler/typechecker/src/main/java/org/mina_lang/typechecker/FreeUnsolvedVariablesFolder.java
+++ b/compiler/typechecker/src/main/java/org/mina_lang/typechecker/FreeUnsolvedVariablesFolder.java
@@ -10,10 +10,10 @@ public class FreeUnsolvedVariablesFolder implements TypeFolder<ImmutableSortedSe
 
     private static Comparator<UnsolvedType> COMPARATOR = Comparator.comparing(UnsolvedType::id);
 
-    private TypeEnvironment environment;
+    private TypeSubstitutionTransformer typeTransformer;
 
-    public FreeUnsolvedVariablesFolder(TypeEnvironment environment) {
-        this.environment = environment;
+    public FreeUnsolvedVariablesFolder(TypeSubstitutionTransformer typeTransformer) {
+        this.typeTransformer = typeTransformer;
     }
 
     @Override
@@ -59,7 +59,7 @@ public class FreeUnsolvedVariablesFolder implements TypeFolder<ImmutableSortedSe
 
     @Override
     public ImmutableSortedSet<UnsolvedType> visitUnsolvedType(UnsolvedType unsolved) {
-        var substituted = unsolved.substitute(environment.typeSubstitution(), environment.kindSubstitution());
+        var substituted = unsolved.accept(typeTransformer);
 
         if (substituted.equals(unsolved)) {
             return SortedSets.immutable.of(COMPARATOR, unsolved);

--- a/compiler/typechecker/src/main/java/org/mina_lang/typechecker/FreeUnsolvedVariablesFolder.java
+++ b/compiler/typechecker/src/main/java/org/mina_lang/typechecker/FreeUnsolvedVariablesFolder.java
@@ -1,0 +1,70 @@
+package org.mina_lang.typechecker;
+
+import java.util.Comparator;
+
+import org.eclipse.collections.api.factory.SortedSets;
+import org.eclipse.collections.api.set.sorted.ImmutableSortedSet;
+import org.mina_lang.common.types.*;
+
+public class FreeUnsolvedVariablesFolder implements TypeFolder<ImmutableSortedSet<UnsolvedType>> {
+
+    private static Comparator<UnsolvedType> COMPARATOR = Comparator.comparing(UnsolvedType::id);
+
+    private TypeEnvironment environment;
+
+    public FreeUnsolvedVariablesFolder(TypeEnvironment environment) {
+        this.environment = environment;
+    }
+
+    @Override
+    public ImmutableSortedSet<UnsolvedType> visitTypeLambda(TypeLambda tyLam) {
+        return tyLam.body().accept(this);
+    }
+
+    @Override
+    public ImmutableSortedSet<UnsolvedType> visitPropositionType(PropositionType propType) {
+        return propType.type().accept(this);
+    }
+
+    @Override
+    public ImmutableSortedSet<UnsolvedType> visitImplicationType(ImplicationType implType) {
+        return implType.impliedType().accept(this);
+    }
+
+    @Override
+    public ImmutableSortedSet<UnsolvedType> visitTypeConstructor(TypeConstructor tyCon) {
+        return SortedSets.immutable.empty(COMPARATOR);
+    }
+
+    @Override
+    public ImmutableSortedSet<UnsolvedType> visitBuiltInType(BuiltInType primTy) {
+        return SortedSets.immutable.empty(COMPARATOR);
+    }
+
+    @Override
+    public ImmutableSortedSet<UnsolvedType> visitTypeApply(TypeApply tyApp) {
+        return tyApp.type().accept(this)
+                .newWithAll(tyApp.typeArguments().flatCollect(tyArg -> tyArg.accept(this)));
+    }
+
+    @Override
+    public ImmutableSortedSet<UnsolvedType> visitForAllVar(ForAllVar forall) {
+        return SortedSets.immutable.empty(COMPARATOR);
+    }
+
+    @Override
+    public ImmutableSortedSet<UnsolvedType> visitExistsVar(ExistsVar exists) {
+        return SortedSets.immutable.empty(COMPARATOR);
+    }
+
+    @Override
+    public ImmutableSortedSet<UnsolvedType> visitUnsolvedType(UnsolvedType unsolved) {
+        var substituted = unsolved.substitute(environment.typeSubstitution(), environment.kindSubstitution());
+
+        if (substituted.equals(unsolved)) {
+            return SortedSets.immutable.of(COMPARATOR, unsolved);
+        } else {
+            return substituted.accept(this);
+        }
+    }
+}

--- a/compiler/typechecker/src/main/java/org/mina_lang/typechecker/Kindchecker.java
+++ b/compiler/typechecker/src/main/java/org/mina_lang/typechecker/Kindchecker.java
@@ -111,11 +111,11 @@ public class Kindchecker {
 
     void mismatchedKind(Range range, Kind actualKind, Kind expectedKind) {
         var expected = expectedKind
-                .substitute(environment.kindSubstitution())
+                .accept(sortTransformer.getKindTransformer())
                 .accept(kindPrinter);
 
         var actual = actualKind
-                .substitute(environment.kindSubstitution())
+                .accept(sortTransformer.getKindTransformer())
                 .accept(kindPrinter);
 
         var message = Doc.group(
@@ -129,11 +129,11 @@ public class Kindchecker {
 
     void mismatchedTypeApplication(Range range, Kind actualKind, Kind expectedKind) {
         var expected = expectedKind
-                .substitute(environment.kindSubstitution())
+                .accept(sortTransformer.getKindTransformer())
                 .accept(kindPrinter);
 
         var actual = actualKind
-                .substitute(environment.kindSubstitution())
+                .accept(sortTransformer.getKindTransformer())
                 .accept(kindPrinter);
 
         var message = Doc.group(
@@ -175,7 +175,7 @@ public class Kindchecker {
 
                 instantiateAsSubKind(
                         newHkResult,
-                        higherSup.resultKind().substitute(environment.kindSubstitution()));
+                        higherSup.resultKind().accept(sortTransformer.getKindTransformer()));
             }
         });
     }
@@ -210,15 +210,15 @@ public class Kindchecker {
 
                 instantiateAsSuperKind(
                         newHkResult,
-                        higherSub.resultKind().substitute(environment.kindSubstitution()));
+                        higherSub.resultKind().accept(sortTransformer.getKindTransformer()));
             }
         });
     }
 
     boolean checkSubKind(Kind subKind, Kind superKind) {
         return withScope(new CheckSubkindScope(), () -> {
-            var solvedSubKind = subKind.substitute(environment.kindSubstitution());
-            var solvedSuperKind = superKind.substitute(environment.kindSubstitution());
+            var solvedSubKind = subKind.accept(sortTransformer.getKindTransformer());
+            var solvedSuperKind = superKind.accept(sortTransformer.getKindTransformer());
 
             if (solvedSubKind == TypeKind.INSTANCE && solvedSuperKind == TypeKind.INSTANCE) {
                 // Complete and Easy's <:Var rule adapted to kinds

--- a/compiler/typechecker/src/main/java/org/mina_lang/typechecker/Kindchecker.java
+++ b/compiler/typechecker/src/main/java/org/mina_lang/typechecker/Kindchecker.java
@@ -60,20 +60,11 @@ public class Kindchecker {
     }
 
     public DataNode<Attributes> kindcheck(DataNode<Name> node) {
-        var inferredData = inferData(node);
-        // FIXME: Defaulting should be done after kind-checking mutually-dependent
-        // groups of definitions in dependency order, not after checking each
-        // definition.
-        var kindDefaulting = new KindDefaultingTransformer(environment.kindSubstitution());
-        var sortTransformer = new SortSubstitutionTransformer(environment.typeSubstitution(), kindDefaulting);
-        return inferredData.accept(new MetaNodeSubstitutionTransformer(sortTransformer));
+        return inferData(node);
     }
 
     public TypeNode<Attributes> kindcheck(TypeNode<Name> node) {
         var inferredType = checkType(node, TypeKind.INSTANCE);
-        // FIXME: Defaulting should be done after kind-checking mutually-dependent
-        // groups of definitions in dependency order, not after checking each
-        // definition.
         var kindDefaulting = new KindDefaultingTransformer(environment.kindSubstitution());
         return inferredType.accept(new TypeNodeSubstitutionTransformer(kindDefaulting));
     }

--- a/compiler/typechecker/src/test/java/org/mina_lang/typechecker/KindcheckerTest.java
+++ b/compiler/typechecker/src/test/java/org/mina_lang/typechecker/KindcheckerTest.java
@@ -9,14 +9,16 @@ import java.util.Map;
 
 import org.eclipse.collections.api.factory.Lists;
 import org.junit.jupiter.api.Test;
-import org.mina_lang.common.*;
+import org.mina_lang.common.Attributes;
+import org.mina_lang.common.Meta;
+import org.mina_lang.common.Range;
 import org.mina_lang.common.diagnostics.Diagnostic;
-import org.mina_lang.common.names.*;
-import org.mina_lang.common.types.HigherKind;
-import org.mina_lang.common.types.SortSubstitutionTransformer;
-import org.mina_lang.common.types.TypeKind;
-import org.mina_lang.common.types.UnsolvedVariableSupply;
+import org.mina_lang.common.names.ForAllVarName;
+import org.mina_lang.common.names.Name;
+import org.mina_lang.common.names.Nameless;
+import org.mina_lang.common.types.*;
 import org.mina_lang.syntax.DataNode;
+import org.mina_lang.syntax.MetaNodeSubstitutionTransformer;
 import org.mina_lang.syntax.TypeNode;
 import org.mina_lang.typechecker.scopes.BuiltInTypingScope;
 import org.mina_lang.typechecker.scopes.ImportedTypesScope;
@@ -33,7 +35,11 @@ public class KindcheckerTest {
         var sortTransformer = new SortSubstitutionTransformer(
             environment.typeSubstitution(), environment.kindSubstitution());
         var kindchecker = new Kindchecker(diagnostics, environment, varSupply, sortTransformer);
-        var kindcheckedNode = kindchecker.kindcheck(originalNode);
+        var kindDefaultingTransformer = new SortSubstitutionTransformer(
+                environment.typeSubstitution(),
+                new KindDefaultingTransformer(environment.kindSubstitution()));
+        var kindcheckedNode = kindchecker.kindcheck(originalNode)
+                .accept(new MetaNodeSubstitutionTransformer(kindDefaultingTransformer));
         assertThat(diagnostics.getDiagnostics(), is(empty()));
         assertThat(kindcheckedNode, is(equalTo(expectedNode)));
     }
@@ -45,7 +51,7 @@ public class KindcheckerTest {
         var diagnostics = new ErrorCollector();
         var varSupply = new UnsolvedVariableSupply();
         var sortTransformer = new SortSubstitutionTransformer(
-            environment.typeSubstitution(), environment.kindSubstitution());
+                environment.typeSubstitution(), environment.kindSubstitution());
         var kindchecker = new Kindchecker(diagnostics, environment, varSupply, sortTransformer);
         var kindcheckedNode = kindchecker.kindcheck(originalNode);
         assertThat(diagnostics.getDiagnostics(), is(empty()));
@@ -58,7 +64,7 @@ public class KindcheckerTest {
         var diagnostics = new ErrorCollector();
         var varSupply = new UnsolvedVariableSupply();
         var sortTransformer = new SortSubstitutionTransformer(
-            environment.typeSubstitution(), environment.kindSubstitution());
+                environment.typeSubstitution(), environment.kindSubstitution());
         var kindchecker = new Kindchecker(diagnostics, environment, varSupply, sortTransformer);
         kindchecker.kindcheck(originalNode);
         var errors = diagnostics.getErrors();
@@ -72,7 +78,7 @@ public class KindcheckerTest {
         var diagnostics = new ErrorCollector();
         var varSupply = new UnsolvedVariableSupply();
         var sortTransformer = new SortSubstitutionTransformer(
-            environment.typeSubstitution(), environment.kindSubstitution());
+                environment.typeSubstitution(), environment.kindSubstitution());
         var kindchecker = new Kindchecker(diagnostics, environment, varSupply, sortTransformer);
         kindchecker.kindcheck(originalNode);
         var errors = diagnostics.getErrors();

--- a/compiler/typechecker/src/test/java/org/mina_lang/typechecker/TypecheckerTest.java
+++ b/compiler/typechecker/src/test/java/org/mina_lang/typechecker/TypecheckerTest.java
@@ -37,6 +37,17 @@ public class TypecheckerTest {
 
     void testSuccessfulTypecheck(
             TypeEnvironment environment,
+            DataNode<Name> originalNode,
+            DataNode<Attributes> expectedNode) {
+        var diagnostics = new ErrorCollector();
+        var typechecker = new Typechecker(diagnostics, environment);
+        var typecheckedNodes = typechecker.typecheck(Lists.immutable.of(originalNode));
+        assertThat(diagnostics.getDiagnostics(), is(empty()));
+        assertThat(typecheckedNodes.getFirst(), is(equalTo(expectedNode)));
+    }
+
+    void testSuccessfulTypecheck(
+            TypeEnvironment environment,
             DeclarationNode<Name> originalNode,
             DeclarationNode<Attributes> expectedNode) {
         var diagnostics = new ErrorCollector();

--- a/examples/DeclareTree.mina
+++ b/examples/DeclareTree.mina
@@ -1,0 +1,22 @@
+namespace Mina/Examples/DeclareTree {
+    data Tree[A] {
+        case Node(root: A, subtrees: Forest[A])
+        case Empty()
+    }
+
+    data Forest[A] {
+        case Cons(head: Tree[A], tail: Forest[A])
+        case Nil()
+    }
+
+    // These definitions are obviously wrong, but we have no arithmetic operators yet!
+    let treeSize[A](tree: Tree[A]) = match tree with {
+        case Empty {} -> 0
+        case Node { subtrees } -> forestSize(subtrees)
+    }
+
+    let forestSize[A](forest: Forest[A]) = match forest with {
+        case Nil {} -> 0
+        case Cons { head, tail } -> treeSize(head)
+    }
+}

--- a/examples/LetEtaReduced.mina
+++ b/examples/LetEtaReduced.mina
@@ -4,7 +4,7 @@ namespace Mina/Examples/LetEtaReduced {
         case None()
     }
 
-    let some = Some
+    let some: A => A -> Option[A] = Some
 
     let someOne = some(1)
 }

--- a/examples/LetPoly.mina
+++ b/examples/LetPoly.mina
@@ -1,23 +1,23 @@
 namespace Mina/Examples/LetPoly {
-    let id: A => A -> A = x -> x
-
-    let idFn[A](a: A): A = a
-
-    let const: [A, B] => (A, B) -> A = (a, b) -> a
-
     let curriedConst: [A, B] => A -> B -> A = a -> b -> a
-
-    let curriedNestedConst: [A, B, C] => A -> B -> C -> A = a -> b -> c -> a
-
-    let constFn[A, B](a: A, b: B): A = a
 
     let one = id(1)
 
     let two =  idFn(1)
 
-    let a = const(const("a", 1.0), id(2))
+    let id: A => A -> A = x -> x
+
+    let idFn[A](a: A): A = a
+
+    let curriedNestedConst: [A, B, C] => A -> B -> C -> A = a -> b -> c -> a
+
+    let a = const(const("a", 1.0), two)
+
+    let const: [A, B] => (A, B) -> A = (a, b) -> a
 
     let i = constFn('i', 2)
 
-    let idViaConst = a -> constFn(a, {})
+    let constFn[A, B](a: A, b: B): A = a
+
+    let idViaConst: A => A -> A = a -> constFn(a, {})
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ gradleVersions = "0.44.0"
 hamcrest = "2.2"
 hamcrestOptional = "1.3.1"
 jacoco = "0.8.8"
+jgrapht = "1.5.1"
 jqwik = "1.7.2"
 junit = "5.9.1"
 junixSocket = "2.6.1"
@@ -31,6 +32,7 @@ eclipseCollectionsApi = { module = "org.eclipse.collections:eclipse-collections-
 gradleVersionsPlugin = { module = "com.github.ben-manes:gradle-versions-plugin", version.ref = "gradleVersions" }
 hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrest" }
 hamcrestOptional = { module = "com.spotify:hamcrest-optional", version.ref = "hamcrestOptional" }
+jgrapht = { module = "org.jgrapht:jgrapht-core", version.ref = "jgrapht" }
 jqwik = { module = "net.jqwik:jqwik", version.ref = "jqwik" }
 julToSlf4j = { module = "org.slf4j:jul-to-slf4j", version.ref = "slf4j" }
 junitJupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }


### PR DESCRIPTION
Changes the `declarations` of `NamespaceNode` into `declarationGroups`, and sorts declarations into those groups according to the strongly connected components of their call graphs in the renaming phase.

This enables us to delay kind defaulting until we have kindchecked a mutually recursive group of definitions, and to check for principal types in the definition of a group of mutually recursive functions.

Another option would be to generalise top-level let bindings using their free unsolved type variables, but I'd prefer to offer this as an LSP code action rather than doing so automagically.