### PR TITLE
Add warning and errors helper methods to diagnostics collector interface

### DIFF
--- a/compiler/common/src/main/java/org/mina_lang/common/diagnostics/BaseDiagnosticCollector.java
+++ b/compiler/common/src/main/java/org/mina_lang/common/diagnostics/BaseDiagnosticCollector.java
@@ -2,12 +2,15 @@ package org.mina_lang.common.diagnostics;
 
 import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.collections.api.list.ImmutableList;
 import org.mina_lang.common.*;
 
 public abstract class BaseDiagnosticCollector implements DiagnosticCollector {
     ConcurrentLinkedQueue<Diagnostic> diagnostics = new ConcurrentLinkedQueue<>();
+    AtomicInteger errorCount = new AtomicInteger(0);
+    AtomicInteger warningCount = new AtomicInteger(0);
 
     public List<Diagnostic> getDiagnostics() {
         return diagnostics.stream().toList();
@@ -16,23 +19,27 @@ public abstract class BaseDiagnosticCollector implements DiagnosticCollector {
     @Override
     public void reportError(Location location, String message) {
         diagnostics.offer(new Diagnostic(location, DiagnosticSeverity.Error, message));
+        errorCount.incrementAndGet();
     }
 
     @Override
     public void reportError(Location location, String message,
             ImmutableList<DiagnosticRelatedInformation> relatedInformation) {
         diagnostics.offer(new Diagnostic(location, DiagnosticSeverity.Error, message, relatedInformation));
+        errorCount.incrementAndGet();
     }
 
     @Override
     public void reportWarning(Location location, String message) {
         diagnostics.offer(new Diagnostic(location, DiagnosticSeverity.Warning, message));
+        warningCount.incrementAndGet();
     }
 
     @Override
     public void reportWarning(Location location, String message,
             ImmutableList<DiagnosticRelatedInformation> relatedInformation) {
         diagnostics.offer(new Diagnostic(location, DiagnosticSeverity.Warning, message, relatedInformation));
+        warningCount.incrementAndGet();
     }
 
     @Override
@@ -55,5 +62,25 @@ public abstract class BaseDiagnosticCollector implements DiagnosticCollector {
     public void reportHint(Location location, String message,
             ImmutableList<DiagnosticRelatedInformation> relatedInformation) {
         diagnostics.offer(new Diagnostic(location, DiagnosticSeverity.Hint, message, relatedInformation));
+    }
+
+    @Override
+    public int errorCount() {
+        return errorCount.get();
+    }
+
+    @Override
+    public int warningCount() {
+        return warningCount.get();
+    }
+
+    @Override
+    public boolean hasErrors() {
+        return errorCount() > 0;
+    }
+
+    @Override
+    public boolean hasWarnings() {
+        return warningCount() > 0;
     }
 }

--- a/compiler/common/src/main/java/org/mina_lang/common/diagnostics/DelegatingDiagnosticCollector.java
+++ b/compiler/common/src/main/java/org/mina_lang/common/diagnostics/DelegatingDiagnosticCollector.java
@@ -69,4 +69,24 @@ public class DelegatingDiagnosticCollector implements ScopedDiagnosticCollector 
     public URI getSourceUri() {
         return sourceUri;
     }
+
+    @Override
+    public int errorCount() {
+        return parent.errorCount();
+    }
+
+    @Override
+    public int warningCount() {
+        return parent.warningCount();
+    }
+
+    @Override
+    public boolean hasErrors() {
+        return parent.hasErrors();
+    }
+
+    @Override
+    public boolean hasWarnings() {
+        return parent.hasWarnings();
+    }
 }

--- a/compiler/common/src/main/java/org/mina_lang/common/diagnostics/DiagnosticCollector.java
+++ b/compiler/common/src/main/java/org/mina_lang/common/diagnostics/DiagnosticCollector.java
@@ -8,6 +8,14 @@ import org.mina_lang.common.Location;
 public interface DiagnosticCollector {
     public List<Diagnostic> getDiagnostics();
 
+    public int errorCount();
+
+    public int warningCount();
+
+    public boolean hasErrors();
+
+    public boolean hasWarnings();
+
     public void reportError(Location location, String message);
 
     public void reportError(Location location, String message, ImmutableList<DiagnosticRelatedInformation> relatedInformation);

--- a/lang-server/src/main/java/org/mina_lang/langserver/MinaTextDocumentService.java
+++ b/lang-server/src/main/java/org/mina_lang/langserver/MinaTextDocumentService.java
@@ -75,13 +75,15 @@ public class MinaTextDocumentService implements TextDocumentService {
                         var codegen = new CodeGenerator();
                         var parsed = parser.parse(charStream);
                         var rangeVisitor = new SyntaxNodeRangeVisitor();
-                        if (diagnostics.getDiagnostics().isEmpty()) {
+                        if (!diagnostics.hasErrors()) {
                             var renamed = renamer.rename(parsed);
-                            if (diagnostics.getDiagnostics().isEmpty()) {
+                            if (!diagnostics.hasErrors()) {
                                 var typed = typechecker.typecheck(renamed);
                                 typed.accept(rangeVisitor);
                                 hoversFuture.complete(rangeVisitor.getRangeNodes());
-                                codegen.generate(storagePath, typed);
+                                if (!diagnostics.hasErrors()) {
+                                    codegen.generate(storagePath, typed);
+                                }
                                 return typed;
                             } else {
                                 renamed.accept(rangeVisitor);
@@ -123,13 +125,15 @@ public class MinaTextDocumentService implements TextDocumentService {
                         var codegen = new CodeGenerator();
                         var parsed = parser.parse(charStream);
                         var rangeVisitor = new SyntaxNodeRangeVisitor();
-                        if (diagnostics.getDiagnostics().isEmpty()) {
+                        if (!diagnostics.hasErrors()) {
                             var renamed = renamer.rename(parsed);
-                            if (diagnostics.getDiagnostics().isEmpty()) {
+                            if (!diagnostics.hasErrors()) {
                                 var typed = typechecker.typecheck(renamed);
                                 typed.accept(rangeVisitor);
                                 hoversFuture.complete(rangeVisitor.getRangeNodes());
-                                codegen.generate(storagePath, typed);
+                                if (!diagnostics.hasErrors()) {
+                                    codegen.generate(storagePath, typed);
+                                }
                                 return typed;
                             } else {
                                 renamed.accept(rangeVisitor);


### PR DESCRIPTION
Adds helper methods to check for presence of errors and warnings, and to get error and warning counts to diagnostic collectors.