### PR TITLE
Working toward import resolution across multiple namespaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ bin/
 build/
 node_modules/
 out/
+# I don't know where these files come from - IntelliJ ANTLR plugin?
+compiler/parser/src/main/gen/
 .classpath
 .jqwik-database
 .project

--- a/compiler/main/src/main/java/org/mina_lang/main/GraphPhase.java
+++ b/compiler/main/src/main/java/org/mina_lang/main/GraphPhase.java
@@ -59,8 +59,7 @@ public non-sealed abstract class GraphPhase<A, B>
     ParallelFlux<NamespaceNode<B>> topoTraverseFrom(NamespaceName startNode) {
         return Optional.ofNullable(inputNodes.get(startNode))
                 .map(inputNode -> {
-                    var nsName = inputNode.id().getName();
-                    var nsDiagnostics = scopedDiagnostics.get(nsName);
+                    var nsDiagnostics = scopedDiagnostics.get(startNode);
                     if (nsDiagnostics.hasErrors()) {
                         return Mono.<NamespaceNode<B>>empty();
                     } else {
@@ -70,8 +69,7 @@ public non-sealed abstract class GraphPhase<A, B>
                 .orElseGet(Mono::empty) // This may happen if the node had errors in a previous phase
                 .doOnNext(transformedNode -> transformedNodes.put(startNode, transformedNode))
                 .flatMapMany(transformedNode -> {
-                    var nsName = transformedNode.id().getName();
-                    var nsDiagnostics = scopedDiagnostics.get(nsName);
+                    var nsDiagnostics = scopedDiagnostics.get(startNode);
                     if (nsDiagnostics.hasErrors()) {
                         return Flux.empty();
                     } else {

--- a/compiler/main/src/main/java/org/mina_lang/main/GraphPhase.java
+++ b/compiler/main/src/main/java/org/mina_lang/main/GraphPhase.java
@@ -92,12 +92,13 @@ public non-sealed abstract class GraphPhase<A, B>
                 .runOn(Schedulers.parallel());
     }
 
-    public Mono<Void> runPhase() {
+    public Mono<ConcurrentHashMap<NamespaceName, NamespaceNode<B>>> runPhase() {
         return Flux.fromIterable(rootNodes)
                 .parallel()
                 .runOn(Schedulers.parallel())
                 .flatMap(this::topoTraverseFrom)
-                .then();
+                .then()
+                .thenReturn(transformedData());
     }
 
     public ConcurrentHashMap<NamespaceName, NamespaceNode<B>> transformedData() {

--- a/compiler/main/src/main/java/org/mina_lang/main/Main.java
+++ b/compiler/main/src/main/java/org/mina_lang/main/Main.java
@@ -154,7 +154,6 @@ public class Main {
                     namespaceNodes.get(namespaceName)
                             .imports()
                             .forEach(imp -> {
-                                // TODO: Handle fully-qualified references
                                 var importName = imp.namespace().getName();
                                 if (namespaceGraph.containsVertex(importName)) {
                                     namespaceGraph.addVertex(importName);

--- a/compiler/main/src/main/java/org/mina_lang/main/Main.java
+++ b/compiler/main/src/main/java/org/mina_lang/main/Main.java
@@ -189,7 +189,7 @@ public class Main {
 
         var parsingPhase = new ParsingPhase(sourceData, scopedDiagnostics, namespaceNodes, mainCollector);
 
-        return Phase.sequenceMono(parsingPhase, parsedNodes -> {
+        return parsingPhase.runPhase().flatMap(parsedNodes -> {
             var namespaceGraph = constructNamespaceGraph(parsedNodes);
 
             // We can't proceed if our namespace graph is badly formed
@@ -198,11 +198,11 @@ public class Main {
             } else {
                 var renamingPhase = new RenamingPhase(namespaceGraph, parsedNodes, scopedDiagnostics);
 
-                var typecheckingPhase = Phase.sequence(renamingPhase, renamedNodes -> {
+                var typecheckingPhase = Phase.andThen(renamingPhase, renamedNodes -> {
                     return new TypecheckingPhase(namespaceGraph, renamedNodes, scopedDiagnostics);
                 });
 
-                var codegenPhase = Phase.sequence(typecheckingPhase, typecheckedNodes -> {
+                var codegenPhase = Phase.andThen(typecheckingPhase, typecheckedNodes -> {
                     return new CodegenPhase(destinationPath, typecheckedNodes, scopedDiagnostics);
                 });
 

--- a/compiler/main/src/main/java/org/mina_lang/main/ParallelPhase.java
+++ b/compiler/main/src/main/java/org/mina_lang/main/ParallelPhase.java
@@ -8,9 +8,10 @@ public non-sealed interface ParallelPhase<A, B> extends Phase<B> {
 
     void consumeInput(A inputNode);
 
-    default Mono<Void> runPhase() {
+    default Mono<B> runPhase() {
         return inputFlux()
                 .doOnNext(this::consumeInput)
-                .then();
+                .then()
+                .thenReturn(transformedData());
     }
 }

--- a/compiler/main/src/main/java/org/mina_lang/main/ParallelPhase.java
+++ b/compiler/main/src/main/java/org/mina_lang/main/ParallelPhase.java
@@ -12,6 +12,12 @@ public non-sealed interface ParallelPhase<A, B> extends Phase<B> {
         return inputFlux()
                 .doOnNext(this::consumeInput)
                 .then()
-                .thenReturn(transformedData());
+                .then(Mono.defer(() -> {
+                    // Mono is not allowed to contain null,
+                    // so this is the only way to deal with Mono<Void>
+                    return transformedData() == null
+                            ? Mono.empty()
+                            : Mono.just(transformedData());
+                }));
     }
 }

--- a/compiler/main/src/main/java/org/mina_lang/main/Phase.java
+++ b/compiler/main/src/main/java/org/mina_lang/main/Phase.java
@@ -5,28 +5,18 @@ import java.util.function.Function;
 import reactor.core.publisher.Mono;
 
 public sealed interface Phase<A> permits GraphPhase, ParallelPhase {
-    Mono<Void> runPhase();
+    Mono<A> runPhase();
     A transformedData();
 
-    static <A, B> Mono<B> sequence(Mono<? extends Phase<A>> phaseMono, Function<A, B> nextPhaseFn) {
-        return phaseMono.flatMap(phase -> {
-            return Phase.sequence(phase, nextPhaseFn);
-        });
+    static <A, B> Mono<B> andThen(Mono<? extends Phase<A>> phaseMono, Function<A, B> nextPhaseFn) {
+        return phaseMono.flatMap(phase -> Phase.andThen(phase, nextPhaseFn));
     }
 
-    static <A, B> Mono<B> sequence(Phase<A> phase, Function<A, B> nextPhaseFn) {
-        return phase.runPhase().then(Mono.fromSupplier(() -> {
-            return nextPhaseFn.apply(phase.transformedData());
-        }));
+    static <A, B> Mono<B> andThen(Phase<A> phase, Function<A, B> nextPhaseFn) {
+        return phase.runPhase().map(nextPhaseFn::apply);
     }
 
-    static <A, B> Mono<B> sequenceMono(Phase<A> phase, Function<A, Mono<B>> nextPhaseFn) {
-        return phase.runPhase().then(Mono.defer(() -> {
-            return nextPhaseFn.apply(phase.transformedData());
-        }));
-    }
-
-    static <A> Mono<Void> runMono(Mono<? extends Phase<A>> phaseMono) {
+    static <A> Mono<A> runMono(Mono<? extends Phase<A>> phaseMono) {
         return phaseMono.flatMap(Phase::runPhase);
     }
 }

--- a/compiler/main/src/test/java/org/mina_lang/main/GraphPhaseTest.java
+++ b/compiler/main/src/test/java/org/mina_lang/main/GraphPhaseTest.java
@@ -73,6 +73,7 @@ public class GraphPhaseTest {
         };
 
         StepVerifier.create(phase.runPhase())
+                .expectNext(namespaceNodes)
                 .expectComplete()
                 .verify();
 

--- a/compiler/parser/src/main/antlr/org/mina_lang/parser/MinaLexer.g4
+++ b/compiler/parser/src/main/antlr/org/mina_lang/parser/MinaLexer.g4
@@ -34,6 +34,8 @@ MATCH: 'match';
 WITH: 'with';
 CASE: 'case';
 
+AS: 'as';
+
 // Block and application delimiters
 LBRACE: '{';
 RBRACE: '}';

--- a/compiler/parser/src/main/antlr/org/mina_lang/parser/MinaParser.g4
+++ b/compiler/parser/src/main/antlr/org/mina_lang/parser/MinaParser.g4
@@ -12,8 +12,11 @@ namespace: NAMESPACE namespaceId LBRACE importDeclaration* declaration* RBRACE E
 importDeclaration: IMPORT importSelector;
 
 importSelector:
-    namespaceId (DOT symbols += ID)?
-    | namespaceId DOT LBRACE symbols += ID (COMMA symbols += ID)* RBRACE;
+    namespaceId (DOT ID)?
+    | namespaceId DOT LBRACE importee (COMMA importee)* RBRACE;
+
+importee:
+    id = ID (AS alias = ID)?;
 
 // Declarations
 declaration: dataDeclaration | letFnDeclaration | letDeclaration;
@@ -125,4 +128,4 @@ literalString: LITERAL_STRING;
 
 // Identifiers
 namespaceId: (pkg += ID RSLASH)* ns = ID;
-qualifiedId: (namespaceId DOT)? ID;
+qualifiedId: (ns = ID DOT)? id = ID;

--- a/compiler/syntax/src/main/java/org/mina_lang/syntax/ImportSymbolNode.java
+++ b/compiler/syntax/src/main/java/org/mina_lang/syntax/ImportSymbolNode.java
@@ -2,7 +2,9 @@ package org.mina_lang.syntax;
 
 import com.opencastsoftware.yvette.Range;
 
-public record ImportSymbolNode(Range range, String symbol) implements SyntaxNode {
+import java.util.Optional;
+
+public record ImportSymbolNode(Range range, String symbol, Optional<String> alias) implements SyntaxNode {
     @Override
     public void accept(SyntaxNodeVisitor visitor) {
         visitor.visitImportSymbol(this);

--- a/compiler/syntax/src/main/java/org/mina_lang/syntax/SyntaxNodes.java
+++ b/compiler/syntax/src/main/java/org/mina_lang/syntax/SyntaxNodes.java
@@ -47,7 +47,11 @@ public class SyntaxNodes {
     }
 
     public static ImportSymbolNode importSymbolNode(Range range, String symbol) {
-        return new ImportSymbolNode(range, symbol);
+        return new ImportSymbolNode(range, symbol, Optional.empty());
+    }
+
+    public static ImportSymbolNode importSymbolNode(Range range, String symbol, Optional<String> alias) {
+        return new ImportSymbolNode(range, symbol, alias);
     }
 
     // Top level declarations

--- a/docs/src/overview.md
+++ b/docs/src/overview.md
@@ -8,7 +8,7 @@ It is a strictly-evaluated, statically-typed language.
 
 ### Syntax
 
-The keywords `namespace`, `import`, `data`, `let`, `if`, `then`, `else`, `match`, `with` and `case` are reserved.
+The keywords `namespace`, `import`, `as`, `data`, `let`, `if`, `then`, `else`, `match`, `with` and `case` are reserved.
 
 `(` and `)` are delimiters for values. They are used for value parameter lists, and for applying values to functions.
 

--- a/vscode-plugin/syntaxes/mina.tmLanguage.json
+++ b/vscode-plugin/syntaxes/mina.tmLanguage.json
@@ -60,6 +60,10 @@
           "name": "keyword.other.import.mina"
         },
         {
+          "match": "\\b(as)\\b",
+          "name": "keyword.other.as.mina"
+        },
+        {
           "match": "\\b(data)\\b",
           "name": "keyword.other.data.mina"
         },


### PR DESCRIPTION
As a general rule the approach to hard problems in this project is to try to solve an easier or more local problem instead. As a result, this PR:
* Bans fully-qualified names in function-level code. This simplifies the process of building a namespace dependency graph by removing the requirement to search all namespaces for fully-qualified references, and leaves all cross-namespace dependency information in the import section of a namespace.
* Adds import aliasing to remove the motivation for allowing fully-qualified references in the code.

TODO:
- [ ] add namespace aliasing in imports - currently only symbol aliasing is supported
- [ ] build an import scope for each module's renaming and typechecking phases based upon the imports that are present
- [ ] store the interface of a namespace as a class file attribute
- [ ] search the classpath for namespaces which are not present in the current project sources and retrieve the class file attribute describing the namespace interface